### PR TITLE
Update coffeescript usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use a `gulpfile.coffee` you need to do two things:
 
 ```javascript
 require('coffee-script/register');
-var gulp = require('./gulpfile.coffee');
+var gulp = module.exports = require('./gulpfile.coffee');
 ```
 
 That's it!. Thanks to [@guillaume86](https://github.com/guillaume86) for the help in the [issue #5](https://github.com/NicoSantangelo/sublime-gulp/issues/5)


### PR DESCRIPTION
Hi there,
I've just found that only after adding the `module.exports =`, in the middle of `var gulp = require('./gulpfile.coffee')`, did it start to work!
So I think that's it.
