### PR TITLE
Additional Gulpfile Paths

### DIFF
--- a/gulp.py
+++ b/gulp.py
@@ -57,6 +57,8 @@ class GulpCommand(BaseCommand):
         for folder_path in self.sercheable_folders:
             self.append_to_gulp_files(folder_path)
             for inner_folder in self.settings.get("gulpfile_paths", []):
+                if(os.name == 'nt'):
+                    inner_folder = inner_folder.replace("/","\\")
                 self.append_to_gulp_files(os.path.join(folder_path, inner_folder))
 
 


### PR DESCRIPTION
If additional paths are added to **User Settings** on Windows OS, the
`/`(forward-slash) raises an error. This fix changes `/`(forward-slash) to
`\\`(back-slash) for Windows OS.  

Tested on Windows & OS X.