### PR TITLE
Updated Snippet Scope

### DIFF
--- a/snippets/gulp.dest('folder').sublime-snippet
+++ b/snippets/gulp.dest('folder').sublime-snippet
@@ -3,5 +3,5 @@
 .pipe(gulp.dest('${1:folder}'));
 ]]></content>
   <tabTrigger>gulpd</tabTrigger>
-  <scope>source.js</scope>
+  <scope>source.js, source.gulpfile.js</scope>
 </snippet>

--- a/snippets/gulp.src('folder').sublime-snippet
+++ b/snippets/gulp.src('folder').sublime-snippet
@@ -4,5 +4,5 @@ gulp.src('${1:files}')
   .pipe(${2:name}('${3:}'))
 ]]></content>
    	<tabTrigger>gulps</tabTrigger>
- 	<scope>source.js</scope>
+   	<scope>source.js, source.gulpfile.js</scope>
 </snippet>

--- a/snippets/gulp.task('name',function).sublime-snippet
+++ b/snippets/gulp.task('name',function).sublime-snippet
@@ -5,5 +5,5 @@ gulp.task('${1:name}',['${2:tasks}'], function() {
 });
 ]]></content>
   <tabTrigger>gulpt</tabTrigger>
-  <scope>source.js</scope>
+  <scope>source.js, source.gulpfile.js</scope>
 </snippet>

--- a/snippets/gulp.watch('file', fn).sublime-snippet
+++ b/snippets/gulp.watch('file', fn).sublime-snippet
@@ -3,5 +3,5 @@
 gulp.watch('${1:files}', ['${2:tasks}']);
 ]]></content>
   <tabTrigger>gulpw</tabTrigger>
-  <scope>source.js</scope>
+  <scope>source.js, source.gulpfile.js</scope>
 </snippet>

--- a/snippets/gulp.watch('files', function(event){}).sublime-snippet
+++ b/snippets/gulp.watch('files', function(event){}).sublime-snippet
@@ -5,5 +5,5 @@ gulp.watch(${1:'file'}, function(event) {
 });
 ]]></content>
   <tabTrigger>gulpwcb</tabTrigger>
-  <scope>source.js</scope>
+  <scope>source.js, source.gulpfile.js</scope>
 </snippet>

--- a/snippets/var gulp = require('name').sublime-snippet
+++ b/snippets/var gulp = require('name').sublime-snippet
@@ -3,5 +3,5 @@
 var ${1:plugin} = require('gulp-${2:name}');
 ]]></content>
     <tabTrigger>vargulp</tabTrigger>
-  <scope>source.js</scope>
+  <scope>source.js, source.gulpfile.js</scope>
 </snippet>


### PR DESCRIPTION
Added ‘source.gulpfile.js’ to each snippet scope.

I'm on Mac OS, Sublime 3 and the snippets work happily in any Javascript file but in a saved gulpfile.js they don't show up for use as the scope 'source.gulpfile.js' is added.

When the snippet scope is edited they work fine.