### PR TITLE
Fix default codepage detection on windows

### DIFF
--- a/cross_platform_codecs.py
+++ b/cross_platform_codecs.py
@@ -32,7 +32,7 @@ class CrossPlatformCodecs():
         (chcp, _) = proccess.communicate()
 
         # Decode using the locale preferred encoding (for example 'cp1251') and remove newlines
-        chcp = chcp.decode(locale.getpreferredencoding()).strip()
+        chcp = chcp.decode(locale.getpreferredencoding()).strip(".\r\n ")
 
         # Get the actual number
         chcp = chcp.split(" ")[-1]


### PR DESCRIPTION
`chcp` on a german windows returns:
Aktive Codepage: 850.\r\n

Because `.strip()` only removes blank and line breaks `850.` becomes
the name of the codepage.

In order to remove the dot from the name we've to add it to the list of
characters we have to remove.

Fixes #89